### PR TITLE
Fixes issue #34

### DIFF
--- a/relativ_osvr_plugin/Relativ_OSVR_Plugin.cpp
+++ b/relativ_osvr_plugin/Relativ_OSVR_Plugin.cpp
@@ -54,7 +54,8 @@ namespace {
 			serial::Serial relativ;
 			std::string last_recv;
 			try {
-				relativ.setTimeout(serial::Timeout::simpleTimeout(1000));
+				serial::Timeout sto = serial::Timeout::simpleTimeout(1000);
+				relativ.setTimeout(sto);
 				relativ.setPort(port);
 				relativ.setBaudrate(115200);
 				while (!relativ.isOpen()) {


### PR DESCRIPTION
issue #34 at https://github.com/relativty/Relativ/issues/34

conversion from 'type' to 'type' function is illegal in every OS except Windows! #34

to prevent it from making the type as reference i.e. "serial::Timeout&" we stored it in variable 'sto' ,
to prevent the error,
error: cannot bind non-const lvalue reference of type ‘serial::Timeout&’ to an rvalue of type ‘serial::Timeout’ 